### PR TITLE
enhance: extract uncommitted non-log load changes

### DIFF
--- a/internal/core/src/exec/operator/MvccNode.cpp
+++ b/internal/core/src/exec/operator/MvccNode.cpp
@@ -74,6 +74,7 @@ PhyMvccNode::GetOutput() {
     }
 
     tracer::AddEvent(fmt::format("input_rows: {}", active_count_));
+    WaitPrefetch();
 
     // Visibility filtering disabled globally: skip all filtering.
     if (!segcore::SegcoreConfig::default_config()

--- a/internal/core/src/exec/operator/MvccNode.h
+++ b/internal/core/src/exec/operator/MvccNode.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/futures/Future.h>
 #include <memory>
 #include <string>
 
@@ -70,13 +71,20 @@ class PhyMvccNode : public Operator {
     PrefetchAsync(const std::shared_ptr<folly::CPUThreadPoolExecutor>
                       prefetch_pool) override {
         auto self = std::static_pointer_cast<PhyMvccNode>(shared_from_this());
-        folly::via(prefetch_pool.get(), [self]() {
+        prefetch_future_ = folly::via(prefetch_pool.get(), [self]() {
             self->segment_->prefetch_chunks(
                 self->operator_context_->get_exec_context()
                     ->get_query_context()
                     ->get_op_context(),
                 TimestampFieldID);
         });
+    }
+
+    void
+    WaitPrefetch() {
+        if (prefetch_future_.valid()) {
+            std::move(prefetch_future_).wait();
+        }
     }
 
  private:
@@ -86,6 +94,7 @@ class PhyMvccNode : public Operator {
     bool is_finished_{false};
     bool is_source_node_{false};
     milvus::Timestamp collection_ttl_timestamp_;
+    folly::Future<folly::Unit> prefetch_future_;
 };
 
 }  // namespace exec

--- a/internal/core/src/storage/PrefetchThreadPool.h
+++ b/internal/core/src/storage/PrefetchThreadPool.h
@@ -6,7 +6,7 @@ inline std::shared_ptr<folly::CPUThreadPoolExecutor>
 GetPrefetchThreadPool() {
     static std::shared_ptr<folly::CPUThreadPoolExecutor> pool =
         std::make_shared<folly::CPUThreadPoolExecutor>(
-            64,
+            24,
             folly::CPUThreadPoolExecutor::makeDefaultPriorityQueue(1),
             std::make_shared<folly::NamedThreadFactory>("MILVUS_PREFETCH_"));
     return pool;

--- a/internal/core/thirdparty/milvus-storage/CMakeLists.txt
+++ b/internal/core/thirdparty/milvus-storage/CMakeLists.txt
@@ -14,7 +14,7 @@
 # Update milvus-storage_VERSION for the first occurrence
 milvus_add_pkg_config("milvus-storage")
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES "")
-set( milvus-storage_VERSION 6f38add)
+set( milvus-storage_VERSION 0b35d53)
 set( GIT_REPOSITORY  "https://github.com/milvus-io/milvus-storage.git")
 message(STATUS "milvus-storage repo: ${GIT_REPOSITORY}")
 message(STATUS "milvus-storage version: ${milvus-storage_VERSION}")

--- a/internal/datacoord/optimistic_txn_persist.go
+++ b/internal/datacoord/optimistic_txn_persist.go
@@ -10,15 +10,15 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/milvus-io/milvus/pkg/v2/log"
-	"github.com/milvus-io/milvus/pkg/v2/util/paramtable"
-	"github.com/milvus-io/milvus/pkg/v2/util/retry"
+	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
+	"github.com/milvus-io/milvus/pkg/v3/util/retry"
 	"github.com/tikv/client-go/v2/txnkv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
 )
 
 var (

--- a/internal/datacoord/segment_info_cache.go
+++ b/internal/datacoord/segment_info_cache.go
@@ -5,10 +5,10 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/milvus-io/milvus-proto/go-api/v2/msgpb"
-	"github.com/milvus-io/milvus/pkg/v2/log"
-	"github.com/milvus-io/milvus/pkg/v2/proto/datapb"
-	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+	"github.com/milvus-io/milvus-proto/go-api/v3/msgpb"
+	"github.com/milvus-io/milvus/pkg/v3/log"
+	"github.com/milvus-io/milvus/pkg/v3/proto/datapb"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 // CachedSegmentsInfo is a concurrent, version-tracked segment metadata store
@@ -148,7 +148,6 @@ func (s *CachedSegmentsInfo) SetSegment(segmentID UniqueID, segment *SegmentInfo
 	s.addCompactTo(segment)
 	return old, existed
 }
-
 
 // DropSegment marks the segment as a tombstone in the cache.
 // The version is retained to reject stale writes.

--- a/internal/datacoord/write_through_cache.go
+++ b/internal/datacoord/write_through_cache.go
@@ -3,7 +3,7 @@ package datacoord
 import (
 	"sync/atomic"
 
-	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 // CacheUpdateFunc modifies a cached value in place.

--- a/internal/flushcommon/writebuffer/buffer_heap.go
+++ b/internal/flushcommon/writebuffer/buffer_heap.go
@@ -3,7 +3,7 @@ package writebuffer
 import (
 	"container/heap"
 
-	"github.com/milvus-io/milvus/pkg/v2/util/typeutil"
+	"github.com/milvus-io/milvus/pkg/v3/util/typeutil"
 )
 
 // bufferHeapItem represents an item in the buffer heap

--- a/internal/util/cgo/pool.go
+++ b/internal/util/cgo/pool.go
@@ -1,19 +1,17 @@
 package cgo
 
 import (
-	"math"
 	"runtime"
 	"time"
 
 	"github.com/milvus-io/milvus/pkg/v3/metrics"
-	"github.com/milvus-io/milvus/pkg/v3/util/hardware"
 	"github.com/milvus-io/milvus/pkg/v3/util/paramtable"
 )
 
 var caller *cgoCaller
 
 func initCaller(nodeID string) {
-	chSize := int64(math.Ceil(float64(hardware.GetCPUNum()) * paramtable.Get().QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat()))
+	chSize := paramtable.Get().QueryNodeCfg.MaxReadConcurrency.GetAsInt() * int(paramtable.Get().QueryNodeCfg.CGOPoolSizeRatio.GetAsFloat())
 	if chSize <= 0 {
 		chSize = 1
 	}


### PR DESCRIPTION
This PR contains only the current uncommitted non-log changes from `/home/ubuntu/milvus`.

Base/head setup:
- Base branch `codex/load-1m-clean-base` rebuilds the current local branch context from `bceb050835` with the non-profile commits `2d61809443` and `4c608294bd`.
- It intentionally skips profile/log commit `32fa0ede29`, which also triggers GitHub push protection from `configs/milvus.yaml`.
- Head branch `codex/uncommitted-nonlog-load-1m` adds one commit with only the filtered uncommitted non-log changes.

Included changes:
- Fix new DataCoord/writebuffer files to import `pkg/v3` / proto v3 packages.
- Size the CGO pool from `MaxReadConcurrency * CGOPoolSizeRatio`.
- Wait for MVCC timestamp prefetch before filtering.
- Reduce the prefetch thread pool size from 64 to 24.
- Update the milvus-storage revision to `0b35d53`.

Excluded intentionally:
- `[sss]`, `[www]`, `[xxx]`, timing/profile logs.
- trace/requestID-only plumbing used by those logs.
- local runtime config changes under `configs/` and `scripts/`.
- untracked artifacts and patch files.

Validation:
- `git diff --check codex/load-1m-clean-base..codex/uncommitted-nonlog-load-1m` passed.
- Log/trace marker scan of the PR diff passed.
- `go test -tags dynamic,test -gcflags="all=-N -l" -run '^$' -count=1 ./internal/datacoord ./internal/util/cgo ./internal/flushcommon/writebuffer` is blocked in this environment because `pkg-config` cannot find `milvus_core.pc` / `milvus-storage.pc`.